### PR TITLE
feat: 新增 deepMerge 深度合并工具函数

### DIFF
--- a/docs/content/docs/6.helpers/object/deep-merge.md
+++ b/docs/content/docs/6.helpers/object/deep-merge.md
@@ -1,0 +1,148 @@
+---
+title: deepMerge
+description: 递归深度合并多个对象，支持数组策略、null 处理和自定义合并函数
+links:
+  - label: GitHub
+    icon: i-lucide-github
+    to: https://github.com/mhaibaraai/movk-core/blob/main/src/helpers/object/deepMerge.ts
+---
+
+## 用法
+
+`deepMerge` 函数将多个 source 对象递归合并为一个新对象，不修改任何输入。
+
+后面的 source 优先级更高，双方都是纯对象的属性会递归合并而非覆盖。支持 Symbol 键，防止原型污染。
+
+```ts
+import { deepMerge } from '@movk/core'
+
+const defaults = { theme: 'light', pagination: { page: 1, size: 10 } }
+const userConfig = { pagination: { size: 20 }, debug: true }
+
+const result = deepMerge([defaults, userConfig])
+// => { theme: 'light', pagination: { page: 1, size: 20 }, debug: true }
+```
+
+### 数组合并策略
+
+```ts
+// concat（默认）：拼接数组
+deepMerge([{ tags: ['a'] }, { tags: ['b'] }])
+// => { tags: ['a', 'b'] }
+
+// replace：整体替换
+deepMerge([{ tags: ['a'] }, { tags: ['b'] }], { arrayStrategy: 'replace' })
+// => { tags: ['b'] }
+
+// unique：拼接并去重
+deepMerge([{ tags: ['a', 'b'] }, { tags: ['b', 'c'] }], { arrayStrategy: 'unique' })
+// => { tags: ['a', 'b', 'c'] }
+```
+
+### null/undefined 处理
+
+```ts
+// skip（默认）：忽略 source 中的 null/undefined
+deepMerge([{ a: 1 }, { a: null }])
+// => { a: 1 }
+
+// override：允许 null/undefined 覆盖
+deepMerge([{ a: 1 }, { a: null }], { nullHandling: 'override' })
+// => { a: null }
+```
+
+### 自定义合并函数
+
+```ts
+// 数值相加而非覆盖
+const result = deepMerge(
+  [{ count: 10 }, { count: 5 }],
+  {
+    customMerger: (key, targetVal, sourceVal) => {
+      if (typeof targetVal === 'number' && typeof sourceVal === 'number')
+        return targetVal + sourceVal
+      return undefined // 交由默认逻辑处理
+    },
+  },
+)
+// => { count: 15 }
+```
+
+## createDeepMerge
+
+使用 `createDeepMerge` 创建预绑定配置的合并函数，避免每次传递 options。
+
+```ts
+import { createDeepMerge } from '@movk/core'
+
+const mergeReplace = createDeepMerge({ arrayStrategy: 'replace' })
+
+mergeReplace([{ tags: ['a'] }, { tags: ['b'] }])
+// => { tags: ['b'] }
+```
+
+## API
+
+### `deepMerge<T>(sources, options?)`{lang="ts-type"}
+
+递归深度合并多个对象。
+
+### 参数
+
+::field-group
+  ::field{name="sources" type="T[]" required}
+  要合并的源对象数组，后面的对象优先级更高。
+  ::
+
+  ::field{name="options" type="DeepMergeOptions"}
+  合并行为配置项。
+  ::
+::
+
+### 返回值
+
+::field-group
+  ::field{name="返回值" type="T"}
+  合并后的新对象，不修改任何输入。
+  ::
+::
+
+### DeepMergeOptions
+
+::field-group
+  ::field{name="arrayStrategy" type="'concat' | 'replace' | 'unique'"}
+  数组合并策略，默认 `'concat'`。
+  ::
+
+  ::field{name="nullHandling" type="'skip' | 'override'"}
+  null/undefined 处理策略，默认 `'skip'`。
+  ::
+
+  ::field{name="customMerger" type="CustomMerger"}
+  自定义合并函数，返回 `undefined` 则交由默认逻辑处理。
+  ::
+::
+
+### `createDeepMerge(options)`{lang="ts-type"}
+
+创建预绑定配置的 deepMerge 函数。
+
+### 参数
+
+::field-group
+  ::field{name="options" type="DeepMergeOptions" required}
+  合并行为配置项。
+  ::
+::
+
+### 返回值
+
+::field-group
+  ::field{name="返回值" type="<T>(sources: T[]) => T"}
+  预配置的 deepMerge 函数。
+  ::
+::
+
+## Changelog
+
+:commit-changelog{prefix="helpers/object"}

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -10,59 +10,59 @@ orientation: horizontal
 ui:
   container: lg:py-20
 ---
-# top
+#top
 :hero-background
 
-# title
-:::motion
-现代 [TypeScript]{.text-primary} 工具函数库.
-:::
+#title
+  :::motion
+  现代 [TypeScript]{.text-primary} 工具函数库.
+  :::
 
 #description
-:::motion
----
-transition: { duration: 0.6, delay: 0.3 }
----
-为 TypeScript 项目设计的现代化工具函数库，涵盖数组、对象、字符串、异步操作等多个方面。全面支持 Tree-Shaking，提供完整类型定义和 Vue 组合式函数。
-:::
+  :::motion
+  ---
+  transition: { duration: 0.6, delay: 0.3 }
+  ---
+  为 TypeScript 项目设计的现代化工具函数库，涵盖数组、对象、字符串、异步操作等多个方面。全面支持 Tree-Shaking，提供完整类型定义和 Vue 组合式函数。
+  :::
 
 #links
-:::motion{class="flex flex-wrap gap-x-6 gap-y-3"}
----
-transition: { duration: 0.6, delay: 0.5 }
----
-  ::::u-button
+  :::motion{class="flex flex-wrap gap-x-6 gap-y-3"}
   ---
-  to: /docs/getting-started
-  size: xl
-  trailing-icon: i-lucide-arrow-right
+  transition: { duration: 0.6, delay: 0.5 }
   ---
-  快速入门
-  ::::
+    ::::u-button
+    ---
+    to: /docs/getting-started
+    size: xl
+    trailing-icon: i-lucide-arrow-right
+    ---
+    快速入门
+    ::::
 
-  ::::u-button
-  ---
-  icon: i-simple-icons-github
-  color: neutral
-  variant: outline
-  size: xl
-  to: https://github.com/mhaibaraai/movk-core
-  target: _blank
-  ---
-  GitHub
-  ::::
-:::
+    ::::u-button
+    ---
+    icon: i-simple-icons-github
+    color: neutral
+    variant: outline
+    size: xl
+    to: https://github.com/mhaibaraai/movk-core
+    target: _blank
+    ---
+    GitHub
+    ::::
+  :::
 
-# default
+#default
 :home
 
 ::
 
 ::u-page-section{class="dark:bg-neutral-950"}
-# title
+#title
 特性一览
 
-# description
+#description
 `@movk/core` 提供了一套全面的、经过严格测试的 TypeScript 工具函数库，旨在简化您的日常开发工作。
 
 #features
@@ -70,10 +70,10 @@ transition: { duration: 0.6, delay: 0.5 }
   ---
   icon: i-lucide-square-dashed
   ---
-  # title
+  #title
   80+ 实用工具
 
-  # description
+  #description
   涵盖数组、对象、字符串、异步操作、URL 处理、树形结构等多个领域，提供丰富、高效的函数，覆盖各种常见场景。
   :::
 
@@ -81,10 +81,10 @@ transition: { duration: 0.6, delay: 0.5 }
   ---
   icon: i-lucide-square-function
   ---
-  # title
+  #title
   Vue 组合式函数
 
-  # description
+  #description
   提供 `useAppStorage`、`useCopyCode` 等即用型 Vue Composables，轻松为 Vue 项目集成响应式能力。
   :::
 
@@ -92,10 +92,10 @@ transition: { duration: 0.6, delay: 0.5 }
   ---
   icon: i-lucide-list-tree
   ---
-  # title
+  #title
   强大的树形结构工具
 
-  # description
+  #description
   内置高效的树形数据结构处理工具，轻松实现查找、遍历、过滤、转换等复杂操作。
   :::
 
@@ -103,10 +103,10 @@ transition: { duration: 0.6, delay: 0.5 }
   ---
   icon: i-lucide-shield-check
   ---
-  # title
+  #title
   完整类型定义
 
-  # description
+  #description
   全面使用 TypeScript 编写，提供完整的类型定义和卓越的类型推断，确保开发体验和代码质量。
   :::
 
@@ -114,10 +114,10 @@ transition: { duration: 0.6, delay: 0.5 }
   ---
   icon: i-lucide-package-check
   ---
-  # title
+  #title
   支持 Tree-Shaking
 
-  # description
+  #description
   精心设计的模块化结构，支持 Tree-Shaking 优化，仅打包您需要的代码，减小生产环境的包体积。
   :::
 
@@ -125,10 +125,10 @@ transition: { duration: 0.6, delay: 0.5 }
   ---
   icon: i-lucide-file-code-2
   ---
-  # title
+  #title
   现代化构建
 
-  # description
+  #description
   原生支持 ES Modules，使用 Unbuild 构建，无缝融入现代前端工程化体系，适用于 Vite、Nuxt 等环境。
   :::
 ::

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -17,6 +17,7 @@ export default antfu({
   rules: {
     'markdown/no-multiple-h1': 'off',
     'markdown/no-empty-links': 'off',
+    'markdown/no-missing-atx-heading-space': 'off',
   },
 }, {
   files: ['bin/**'],

--- a/src/helpers/object/deepMerge.ts
+++ b/src/helpers/object/deepMerge.ts
@@ -1,0 +1,237 @@
+import type { AnyObject } from '../../types/object'
+import { isPlainObject } from '../../validators/isPlainObject'
+
+/**
+ * 数组合并策略
+ * - `'concat'`  : 将 source 数组拼接在 target 数组之后（默认）
+ * - `'replace'` : 用 source 数组整体替换 target 数组
+ * - `'unique'`  : 拼接后去重（基于 SameValueZero 比较）
+ */
+export type ArrayMergeStrategy = 'concat' | 'replace' | 'unique'
+
+/**
+ * null/undefined 处理策略
+ * - `'skip'`     : 忽略 source 中的 null/undefined，保留 target 中的值（默认）
+ * - `'override'` : 允许 source 中的 null/undefined 覆盖 target 中的值
+ */
+export type NullHandlingStrategy = 'skip' | 'override'
+
+/**
+ * 自定义合并函数。
+ *
+ * @param key       当前正在处理的键（string 或 Symbol）
+ * @param targetVal target 中该键的当前值
+ * @param sourceVal source 中该键的值
+ * @param path      从根对象到当前层级的键路径
+ * @returns         返回合并结果；返回 `undefined` 则交由默认逻辑处理
+ */
+export type CustomMerger = (
+  key: string | symbol,
+  targetVal: unknown,
+  sourceVal: unknown,
+  path: ReadonlyArray<string | symbol>,
+) => unknown
+
+/**
+ * deepMerge 配置选项
+ */
+export interface DeepMergeOptions {
+  /** 数组合并策略，默认 `'concat'` */
+  arrayStrategy?: ArrayMergeStrategy
+  /** null/undefined 处理策略，默认 `'skip'` */
+  nullHandling?: NullHandlingStrategy
+  /** 自定义合并函数，返回 `undefined` 则交由默认逻辑处理 */
+  customMerger?: CustomMerger
+}
+
+/** 需要跳过的危险键，防止原型污染 */
+const FORBIDDEN_KEYS = new Set<string>(['__proto__', 'constructor'])
+
+interface ResolvedOptions {
+  arrayStrategy: ArrayMergeStrategy
+  nullHandling: NullHandlingStrategy
+  customMerger: CustomMerger | undefined
+}
+
+function resolveOptions(options?: DeepMergeOptions): ResolvedOptions {
+  return {
+    arrayStrategy: options?.arrayStrategy ?? 'concat',
+    nullHandling: options?.nullHandling ?? 'skip',
+    customMerger: options?.customMerger,
+  }
+}
+
+/**
+ * 获取对象的所有自有键（string + symbol）
+ */
+function getOwnKeys(obj: object): Array<string | symbol> {
+  return [
+    ...Object.keys(obj),
+    ...Object.getOwnPropertySymbols(obj).filter(
+      sym => Object.prototype.propertyIsEnumerable.call(obj, sym),
+    ),
+  ]
+}
+
+/**
+ * 合并两个对象（内部递归核心）
+ */
+function mergeTwo(
+  target: AnyObject,
+  source: AnyObject,
+  config: ResolvedOptions,
+  path: Array<string | symbol>,
+  cache: WeakMap<object, object>,
+): AnyObject {
+  const result = { ...target }
+
+  for (const key of getOwnKeys(source)) {
+    if (typeof key === 'string' && FORBIDDEN_KEYS.has(key))
+      continue
+
+    const targetVal = result[key as string]
+    const sourceVal = source[key as string]
+
+    // 1. 自定义合并优先
+    if (config.customMerger) {
+      const customResult = config.customMerger(key, targetVal, sourceVal, path)
+      if (customResult !== undefined) {
+        ;(result as any)[key] = customResult
+        continue
+      }
+    }
+
+    // 2. null/undefined 处理
+    if (sourceVal === null || sourceVal === undefined) {
+      if (config.nullHandling === 'skip' && key in result) {
+        continue
+      }
+      ;(result as any)[key] = sourceVal
+      continue
+    }
+
+    // 3. 数组合并
+    if (Array.isArray(sourceVal)) {
+      if (Array.isArray(targetVal)) {
+        switch (config.arrayStrategy) {
+          case 'replace':
+            ;(result as any)[key] = [...sourceVal]
+            break
+          case 'unique':
+            ;(result as any)[key] = [...new Set([...targetVal, ...sourceVal])]
+            break
+          case 'concat':
+          default:
+            ;(result as any)[key] = [...targetVal, ...sourceVal]
+            break
+        }
+      }
+      else {
+        ;(result as any)[key] = [...sourceVal]
+      }
+      continue
+    }
+
+    // 4. 纯对象递归合并
+    if (isPlainObject(sourceVal)) {
+      if (cache.has(sourceVal)) {
+        ;(result as any)[key] = cache.get(sourceVal)
+        continue
+      }
+
+      const nextPath = [...path, key]
+      const placeholder: AnyObject = {}
+      cache.set(sourceVal, placeholder)
+
+      if (isPlainObject(targetVal)) {
+        const merged = mergeTwo(targetVal, sourceVal, config, nextPath, cache)
+        Object.assign(placeholder, merged)
+        ;(result as any)[key] = placeholder
+      }
+      else {
+        const cloned = mergeTwo({}, sourceVal, config, nextPath, cache)
+        Object.assign(placeholder, cloned)
+        ;(result as any)[key] = placeholder
+      }
+      continue
+    }
+
+    // 5. 其他类型（原始值、Date、Map、Set、RegExp 等）直接替换
+    ;(result as any)[key] = sourceVal
+  }
+
+  return result
+}
+
+/**
+ * 递归地将多个 source 对象深度合并为一个新对象。
+ *
+ * - 后面的 source 优先级更高，会覆盖前面的同名属性
+ * - 双方都是纯对象的属性会递归合并，而非覆盖
+ * - 数组合并策略、null 处理和自定义合并函数均可配置
+ * - 支持 Symbol 键，防止原型污染（跳过 `__proto__` 和 `constructor`）
+ * - 不修改任何输入对象
+ *
+ * @category Object
+ * @typeParam T 合并结果的对象类型
+ * @param sources 要合并的源对象数组，后面的对象优先级更高
+ * @param options 合并行为配置项（可选）
+ * @returns 合并后的新对象
+ *
+ * @example
+ * ```ts
+ * const defaults = { theme: 'light', pagination: { page: 1, size: 10 } }
+ * const userConfig = { pagination: { size: 20 }, debug: true }
+ * const result = deepMerge([defaults, userConfig])
+ * // => { theme: 'light', pagination: { page: 1, size: 20 }, debug: true }
+ * ```
+ *
+ * @example
+ * ```ts
+ * // 数组去重合并
+ * const result = deepMerge(
+ *   [{ tags: ['a', 'b'] }, { tags: ['b', 'c'] }],
+ *   { arrayStrategy: 'unique' },
+ * )
+ * // => { tags: ['a', 'b', 'c'] }
+ * ```
+ */
+export function deepMerge<T extends AnyObject>(
+  sources: T[],
+  options?: DeepMergeOptions,
+): T {
+  if (!Array.isArray(sources))
+    return {} as T
+
+  const config = resolveOptions(options)
+  const validSources = sources.filter(isPlainObject)
+
+  if (validSources.length === 0)
+    return {} as T
+
+  const cache = new WeakMap<object, object>()
+  return validSources.reduce<AnyObject>(
+    (acc, source) => mergeTwo(acc, source, config, [], cache),
+    {},
+  ) as T
+}
+
+/**
+ * 创建一个预绑定配置的 deepMerge 函数。
+ *
+ * @category Object
+ * @param options 合并行为配置项
+ * @returns 预配置的 deepMerge 函数
+ *
+ * @example
+ * ```ts
+ * const mergeReplace = createDeepMerge({ arrayStrategy: 'replace' })
+ * const result = mergeReplace([{ tags: ['a'] }, { tags: ['b'] }])
+ * // => { tags: ['b'] }
+ * ```
+ */
+export function createDeepMerge(
+  options: DeepMergeOptions,
+): <T extends AnyObject>(sources: T[]) => T {
+  return <T extends AnyObject>(sources: T[]): T => deepMerge(sources, options)
+}

--- a/src/helpers/object/index.ts
+++ b/src/helpers/object/index.ts
@@ -1,4 +1,5 @@
 export * from './deepClone'
+export * from './deepMerge'
 export * from './omit'
 export * from './omitUndefined'
 export * from './pick'

--- a/src/types/object/deep.ts
+++ b/src/types/object/deep.ts
@@ -1,3 +1,5 @@
+import type { IsPlainObject } from './basic'
+
 /**
  * 递归将对象类型 `T` 的所有属性变为可选(深可选)。
  * @typeParam T - 源对象类型
@@ -9,3 +11,38 @@
 export type DeepPartial<T> = {
   [P in keyof T]?: T[P] extends object ? DeepPartial<T[P]> : T[P] | undefined;
 }
+
+/** 递归深度计数器，用于限制类型递归层数 */
+type MergeDepth = [never, 0, 1, 2, 3, 4]
+
+/**
+ * 递归合并两个对象类型，`U` 中的属性优先级高于 `T`。
+ * 仅对双方都是纯对象的属性做深度递归，其余类型直接取 `U` 的值。
+ *
+ * @typeParam T - 基础对象类型
+ * @typeParam U - 覆盖对象类型
+ * @typeParam D - 递归深度限制，默认为 4
+ *
+ * @example
+ * ```ts
+ * type A = { a: { b: number; c: string }; d: boolean }
+ * type B = { a: { b: string; e: number }; f: Date }
+ * type R = DeepMerge<A, B>
+ * // { a: { b: string; c: string; e: number }; d: boolean; f: Date }
+ * ```
+ */
+export type DeepMerge<T, U, D extends number = 4> = [D] extends [never]
+  ? T & U
+  : {
+      [K in keyof T | keyof U]: K extends keyof U
+        ? K extends keyof T
+          ? IsPlainObject<T[K]> extends true
+            ? IsPlainObject<U[K]> extends true
+              ? DeepMerge<NonNullable<T[K]>, NonNullable<U[K]>, MergeDepth[D]>
+              : U[K]
+            : U[K]
+          : U[K]
+        : K extends keyof T
+          ? T[K]
+          : never
+    }

--- a/tests/helpers/object/deep-merge.test.ts
+++ b/tests/helpers/object/deep-merge.test.ts
@@ -1,0 +1,284 @@
+import { describe, expect, it } from 'vitest'
+import { createDeepMerge, deepMerge } from '../../../src/helpers/object'
+
+describe('deepMerge', () => {
+  // ---- 基础合并 ----
+
+  it('应该合并两个扁平对象', () => {
+    const result = deepMerge([{ a: 1 }, { b: 2 }])
+    expect(result).toEqual({ a: 1, b: 2 })
+  })
+
+  it('应该返回新对象，不修改任何输入', () => {
+    const obj1 = { a: 1, nested: { x: 1 } }
+    const obj2 = { b: 2, nested: { y: 2 } }
+    const result = deepMerge([obj1, obj2])
+
+    expect(result).not.toBe(obj1)
+    expect(result).not.toBe(obj2)
+    expect(obj1).toEqual({ a: 1, nested: { x: 1 } })
+    expect(obj2).toEqual({ b: 2, nested: { y: 2 } })
+  })
+
+  it('后面的 source 优先级更高', () => {
+    const result = deepMerge([{ a: 1 }, { a: 2 }, { a: 3 }])
+    expect(result.a).toBe(3)
+  })
+
+  it('sources 为空数组时返回空对象', () => {
+    const result = deepMerge([])
+    expect(result).toEqual({})
+  })
+
+  it('单个 source 时等同于浅拷贝', () => {
+    const source = { a: 1, b: { c: 2 } }
+    const result = deepMerge([source])
+    expect(result).toEqual(source)
+    expect(result).not.toBe(source)
+  })
+
+  it('非数组参数时返回空对象', () => {
+    const result = deepMerge(null as any)
+    expect(result).toEqual({})
+  })
+
+  it('过滤掉非 plain object 的项', () => {
+    const result = deepMerge([{ a: 1 }, null as any, 42 as any, { b: 2 }])
+    expect(result).toEqual({ a: 1, b: 2 })
+  })
+
+  // ---- 深度合并 ----
+
+  it('应该递归合并嵌套的纯对象', () => {
+    const defaults = { theme: 'light', pagination: { page: 1, size: 10 } }
+    const userConfig = { pagination: { size: 20 }, debug: true }
+    const result = deepMerge([defaults, userConfig])
+    expect(result).toEqual({
+      theme: 'light',
+      pagination: { page: 1, size: 20 },
+      debug: true,
+    })
+  })
+
+  it('应该保留 target 中 source 未涉及的嵌套键', () => {
+    const result = deepMerge([
+      { a: { b: 1, c: 2, d: { e: 3 } } },
+      { a: { b: 10 } },
+    ])
+    expect(result).toEqual({ a: { b: 10, c: 2, d: { e: 3 } } })
+  })
+
+  it('应该正确处理三层及以上嵌套', () => {
+    const result = deepMerge([
+      { a: { b: { c: { d: 1, e: 2 } } } },
+      { a: { b: { c: { d: 10, f: 3 } } } },
+    ])
+    expect(result).toEqual({ a: { b: { c: { d: 10, e: 2, f: 3 } } } })
+  })
+
+  it('source 为纯对象但 target 为非对象时，source 覆盖', () => {
+    const result = deepMerge([{ a: 'string' }, { a: { nested: 1 } }])
+    expect(result).toEqual({ a: { nested: 1 } })
+  })
+
+  // ---- 数组策略 ----
+
+  it('arrayStrategy: \'concat\' 应该拼接数组（默认）', () => {
+    const result = deepMerge([{ tags: ['a', 'b'] }, { tags: ['c'] }])
+    expect(result.tags).toEqual(['a', 'b', 'c'])
+  })
+
+  it('arrayStrategy: \'replace\' 应该替换数组', () => {
+    const result = deepMerge(
+      [{ tags: ['a', 'b'] }, { tags: ['c'] }],
+      { arrayStrategy: 'replace' },
+    )
+    expect(result.tags).toEqual(['c'])
+  })
+
+  it('arrayStrategy: \'unique\' 应该拼接并去重', () => {
+    const result = deepMerge(
+      [{ tags: ['a', 'b'] }, { tags: ['b', 'c'] }],
+      { arrayStrategy: 'unique' },
+    )
+    expect(result.tags).toEqual(['a', 'b', 'c'])
+  })
+
+  it('source 有数组而 target 没有时，应该直接使用 source 数组', () => {
+    const result = deepMerge([{ a: 1 }, { tags: ['x'] }])
+    expect(result.tags).toEqual(['x'])
+  })
+
+  it('source 有数组而 target 该键不是数组时，应该使用 source 数组', () => {
+    const result = deepMerge([{ tags: 'not-array' }, { tags: ['x'] }])
+    expect(result.tags).toEqual(['x'])
+  })
+
+  // ---- null/undefined 处理 ----
+
+  it('nullHandling: \'skip\' 时应该忽略 source 中的 null（默认）', () => {
+    const result = deepMerge([{ a: 1 }, { a: null }])
+    expect(result.a).toBe(1)
+  })
+
+  it('nullHandling: \'skip\' 时应该忽略 source 中的 undefined（默认）', () => {
+    const result = deepMerge([{ a: 1 }, { a: undefined }])
+    expect(result.a).toBe(1)
+  })
+
+  it('nullHandling: \'override\' 时应该允许 null 覆盖', () => {
+    const result = deepMerge(
+      [{ a: 1 }, { a: null }],
+      { nullHandling: 'override' },
+    )
+    expect(result.a).toBeNull()
+  })
+
+  it('nullHandling: \'override\' 时应该允许 undefined 覆盖', () => {
+    const result = deepMerge(
+      [{ a: 1 }, { a: undefined }],
+      { nullHandling: 'override' },
+    )
+    expect(result.a).toBeUndefined()
+  })
+
+  it('nullHandling: \'skip\' 且 target 中无该键时，null 值应被写入', () => {
+    const result = deepMerge([{ a: 1 }, { b: null }])
+    expect(result.b).toBeNull()
+  })
+
+  // ---- Symbol 键 ----
+
+  it('应该合并 Symbol 键的属性', () => {
+    const sym = Symbol('test')
+    const result = deepMerge([{ [sym]: 'a' }, { [sym]: 'b' }])
+    expect(result[sym]).toBe('b')
+  })
+
+  it('应该保留不同 Symbol 键', () => {
+    const sym1 = Symbol('one')
+    const sym2 = Symbol('two')
+    const result = deepMerge([{ [sym1]: 1 }, { [sym2]: 2 }])
+    expect(result[sym1]).toBe(1)
+    expect(result[sym2]).toBe(2)
+  })
+
+  // ---- 原型污染防护 ----
+
+  it('应该跳过 __proto__ 键', () => {
+    const malicious = JSON.parse('{"__proto__": {"polluted": true}}')
+    const result = deepMerge([{}, malicious])
+    expect(({} as any).polluted).toBeUndefined()
+    expect(result.polluted).toBeUndefined()
+  })
+
+  it('应该跳过 constructor 键', () => {
+    const source = { constructor: 'evil' } as any
+    const result = deepMerge([{}, source])
+    expect(result.constructor).toBe(Object)
+    expect(Object.hasOwn(result, 'constructor')).toBe(false)
+  })
+
+  // ---- 特殊对象类型 ----
+
+  it('date 对象应该被替换，不递归合并', () => {
+    const date1 = new Date('2024-01-01')
+    const date2 = new Date('2025-01-01')
+    const result = deepMerge([{ d: date1 }, { d: date2 }])
+    expect(result.d).toBe(date2)
+  })
+
+  it('regExp 对象应该被替换，不递归合并', () => {
+    const result = deepMerge([{ r: /abc/g }, { r: /xyz/i }])
+    expect(result.r).toEqual(/xyz/i)
+  })
+
+  it('map 对象应该被替换，不递归合并', () => {
+    const map1 = new Map([['a', 1]])
+    const map2 = new Map([['b', 2]])
+    const result = deepMerge([{ m: map1 }, { m: map2 }])
+    expect(result.m).toBe(map2)
+  })
+
+  it('set 对象应该被替换，不递归合并', () => {
+    const set1 = new Set([1])
+    const set2 = new Set([2])
+    const result = deepMerge([{ s: set1 }, { s: set2 }])
+    expect(result.s).toBe(set2)
+  })
+
+  // ---- 循环引用 ----
+
+  it('应该处理 source 中的循环引用，不陷入无限递归', () => {
+    const obj: any = { a: 1 }
+    obj.self = obj
+    const result = deepMerge([{ x: 'base' }, obj])
+    expect(result.a).toBe(1)
+    expect(result.x).toBe('base')
+  })
+
+  // ---- 自定义 merger ----
+
+  it('customMerger 返回非 undefined 时应该使用其结果', () => {
+    const result = deepMerge(
+      [{ count: 10 }, { count: 5 }],
+      {
+        customMerger: (_key, targetVal, sourceVal) => {
+          if (typeof targetVal === 'number' && typeof sourceVal === 'number')
+            return targetVal + sourceVal
+          return undefined
+        },
+      },
+    )
+    expect(result.count).toBe(15)
+  })
+
+  it('customMerger 返回 undefined 时应该退回默认逻辑', () => {
+    const result = deepMerge(
+      [{ a: 1, b: 'x' }, { a: 2, b: 'y' }],
+      {
+        customMerger: (_key, targetVal, sourceVal) => {
+          if (typeof targetVal === 'number' && typeof sourceVal === 'number')
+            return targetVal + sourceVal
+          return undefined
+        },
+      },
+    )
+    expect(result.a).toBe(3)
+    expect(result.b).toBe('y')
+  })
+
+  it('customMerger 应该接收正确的 path 参数', () => {
+    const paths: Array<ReadonlyArray<string | symbol>> = []
+    deepMerge(
+      [{ a: { b: { c: 1 } } }, { a: { b: { c: 2 } } }],
+      {
+        customMerger: (_key, _targetVal, _sourceVal, path) => {
+          paths.push([...path])
+          return undefined
+        },
+      },
+    )
+    expect(paths).toContainEqual([])
+    expect(paths).toContainEqual(['a'])
+    expect(paths).toContainEqual(['a', 'b'])
+  })
+
+  // ---- createDeepMerge ----
+
+  it('createDeepMerge 应该返回预绑定配置的函数', () => {
+    const mergeReplace = createDeepMerge({ arrayStrategy: 'replace' })
+    const result = mergeReplace([{ tags: ['a'] }, { tags: ['b'] }])
+    expect(result.tags).toEqual(['b'])
+  })
+
+  it('createDeepMerge 的多次调用应该互不影响', () => {
+    const mergeReplace = createDeepMerge({ arrayStrategy: 'replace' })
+    const mergeUnique = createDeepMerge({ arrayStrategy: 'unique' })
+
+    const sources = [{ tags: ['a', 'b'] }, { tags: ['b', 'c'] }] as const
+
+    expect(mergeReplace([...sources]).tags).toEqual(['b', 'c'])
+    expect(mergeUnique([...sources]).tags).toEqual(['a', 'b', 'c'])
+  })
+})


### PR DESCRIPTION
## Summary

- 实现策略可配置的 `deepMerge(sources, options?)` 递归深度合并函数，与现有 `deepClone` 形成克隆-合并工具对
- 实现 `createDeepMerge(options)` 工厂函数，支持预绑定配置复用
- 新增 `DeepMerge<T, U>` 递归类型定义，支持类型级深度合并推断（深度上限 4 层）
- 补充 35 个单元测试覆盖全部边界情况，新增文档页

## 功能特性

| 特性 | 说明 |
|------|------|
| 数组合并策略 | `concat`（默认）、`replace`、`unique` |
| null 处理策略 | `skip`（默认）、`override` |
| 自定义合并函数 | `customMerger(key, targetVal, sourceVal, path)` |
| Symbol 键支持 | 正确合并 Symbol 键属性（修复 defu 的已知限制） |
| 原型污染防护 | 跳过 `__proto__` 和 `constructor` 键 |
| 循环引用保护 | WeakMap 占位对象模式，防止无限递归 |
| 不可变 | 不修改任何输入对象 |

## Test plan

- [x] `pnpm test run tests/helpers/object/deep-merge.test.ts` — 35 个测试全部通过
- [x] `pnpm test run` — 全量 364 个测试通过
- [x] `pnpm typecheck` — 类型检查通过
- [x] `pnpm lint` — ESLint 检查通过
- [x] `pnpm build` — 构建成功，导出列表已包含 `deepMerge` 和 `createDeepMerge`