### PR TITLE
refactor: 重构 vue.ts 组件类型提取，增强泛型 SFC 支持

### DIFF
--- a/src/types/vue.ts
+++ b/src/types/vue.ts
@@ -2,8 +2,10 @@ import type { Component, DefineComponent } from 'vue'
 import type { StringOrVNode } from './object'
 
 /**
- * vue-component-type-helpers
- * Copy from https://github.com/vuejs/language-tools/tree/master/packages/component-type-helpers
+ * 增强版组件类型提取，支持泛型 SFC 的三种 vue-tsc 编译签名模式：
+ * - 模式 A：函数参数可直接解析 → Parameters<T>[0]
+ * - 模式 A'：参数自引用（返回 any）→ 返回值 __ctx 成员
+ * - 模式 B：DefineComponent 包装 → InstanceType<T>['$props']
  */
 
 export type IsComponent = StringOrVNode | Component | DefineComponent | ((...args: any[]) => any)
@@ -12,22 +14,115 @@ export type ComponentType<T> = T extends new (...args: any) => {} ? 1
   : T extends (...args: any) => any ? 2
     : 0
 
-export type ComponentProps<T> = T extends new (...args: any) => { $props: infer P } ? NonNullable<P>
-  : T extends (props: infer P, ...args: any) => any ? P
-    : {}
+/** 检测 any 类型 */
+type _IsAny<T> = 0 extends (1 & T) ? true : false
 
-export type ComponentSlots<T> = T extends new (...args: any) => { $slots: infer S } ? NonNullable<S>
-  : T extends (props: any, ctx: { slots: infer S, attrs: any, emit: any }, ...args: any) => any ? NonNullable<S>
-    : {}
+/** 从构造器组件提取 InstanceType 成员，映射展平避免 TS 延迟求值 */
+type _InstanceTypeMember<T, K extends string>
+  = T extends abstract new (...args: any) => infer I
+    ? K extends keyof I
+      ? { [P in keyof I[K]]: I[K][P] }
+      : never
+    : never
 
-export type ComponentAttrs<T> = T extends new (...args: any) => { $attrs: infer A } ? NonNullable<A>
-  : T extends (props: any, ctx: { slots: any, attrs: infer A, emit: any }, ...args: any) => any ? NonNullable<A>
-    : {}
+/** 从可调用组件提取第一个参数（props），排除 any/never */
+type _FnParam<T>
+  = T extends (...args: any) => any
+    ? [Parameters<T>[0]] extends [never] ? never
+        : _IsAny<Parameters<T>[0]> extends true ? never
+          : Parameters<T>[0]
+    : never
 
-export type ComponentEmit<T> = T extends new (...args: any) => { $emit: infer E } ? NonNullable<E>
-  : T extends (props: any, ctx: { slots: any, attrs: any, emit: infer E }, ...args: any) => any ? NonNullable<E>
-    : {}
+/** 从可调用组件的 ctx 参数提取指定成员（slots/attrs/emit） */
+type _FnCtxMember<T, K extends string>
+  = T extends (props: any, ctx: infer Ctx, ...args: any) => any
+    ? Ctx extends Record<K, infer M> ? NonNullable<M> : never
+    : never
 
+/** 从返回值 __ctx 提取指定字段（模式 A'：参数自引用时 __ctx 仍可解析） */
+type _ReturnCtxMember<T, K extends string>
+  = T extends (...args: any) => infer R
+    ? R extends { __ctx?: infer Ctx }
+      ? Ctx extends Record<K, infer M>
+        ? _IsAny<M> extends true ? never : { [P in keyof M]: M[P] }
+        : never
+      : never
+    : never
+
+/**
+ * 组件 Props 提取
+ * - 模式 A  → Parameters[0]
+ * - 模式 A' → __ctx.props
+ * - 模式 B  → $props
+ * - 回退    → {}
+ */
+export type ComponentProps<T>
+  = _FnParam<T> extends never
+    ? _ReturnCtxMember<T, 'props'> extends never
+      ? _InstanceTypeMember<T, '$props'> extends never ? {} : NonNullable<_InstanceTypeMember<T, '$props'>>
+      : NonNullable<_ReturnCtxMember<T, 'props'>>
+    : _FnParam<T>
+
+/**
+ * 组件 Slots 提取
+ * - 模式 A  → ctx.slots
+ * - 模式 A' → __ctx.slots
+ * - 模式 B  → $slots
+ * - 回退    → {}
+ */
+export type ComponentSlots<T>
+  = _IsAny<_FnCtxMember<T, 'slots'>> extends true
+    ? _ReturnCtxMember<T, 'slots'> extends never
+      ? _InstanceTypeMember<T, '$slots'> extends never ? {} : NonNullable<_InstanceTypeMember<T, '$slots'>>
+      : _ReturnCtxMember<T, 'slots'>
+    : [_FnCtxMember<T, 'slots'>] extends [never]
+        ? _ReturnCtxMember<T, 'slots'> extends never
+          ? _InstanceTypeMember<T, '$slots'> extends never ? {} : NonNullable<_InstanceTypeMember<T, '$slots'>>
+          : _ReturnCtxMember<T, 'slots'>
+        : _FnCtxMember<T, 'slots'>
+
+/**
+ * 组件 Attrs 提取
+ * - 模式 A  → ctx.attrs
+ * - 模式 A' → __ctx.attrs
+ * - 模式 B  → $attrs
+ * - 回退    → {}
+ */
+export type ComponentAttrs<T>
+  = _IsAny<_FnCtxMember<T, 'attrs'>> extends true
+    ? _ReturnCtxMember<T, 'attrs'> extends never
+      ? _InstanceTypeMember<T, '$attrs'> extends never ? {} : NonNullable<_InstanceTypeMember<T, '$attrs'>>
+      : _ReturnCtxMember<T, 'attrs'>
+    : [_FnCtxMember<T, 'attrs'>] extends [never]
+        ? _ReturnCtxMember<T, 'attrs'> extends never
+          ? _InstanceTypeMember<T, '$attrs'> extends never ? {} : NonNullable<_InstanceTypeMember<T, '$attrs'>>
+          : _ReturnCtxMember<T, 'attrs'>
+        : _FnCtxMember<T, 'attrs'>
+
+/**
+ * 组件 Emit 提取
+ * - 模式 A  → ctx.emit
+ * - 模式 A' → __ctx.emit
+ * - 模式 B  → $emit
+ * - 回退    → {}
+ */
+export type ComponentEmit<T>
+  = _IsAny<_FnCtxMember<T, 'emit'>> extends true
+    ? _ReturnCtxMember<T, 'emit'> extends never
+      ? _InstanceTypeMember<T, '$emit'> extends never ? {} : NonNullable<_InstanceTypeMember<T, '$emit'>>
+      : _ReturnCtxMember<T, 'emit'>
+    : [_FnCtxMember<T, 'emit'>] extends [never]
+        ? _ReturnCtxMember<T, 'emit'> extends never
+          ? _InstanceTypeMember<T, '$emit'> extends never ? {} : NonNullable<_InstanceTypeMember<T, '$emit'>>
+          : _ReturnCtxMember<T, 'emit'>
+        : _FnCtxMember<T, 'emit'>
+
+/**
+ * 组件 Exposed 提取
+ * - 构造器  → InstanceType<T>
+ * - 可调用  → expose 参数
+ * - 回退    → {}
+ */
 export type ComponentExposed<T> = T extends new (...args: any) => infer E ? E
   : T extends (props: any, ctx: any, expose: (exposed: infer E) => any, ...args: any) => any ? NonNullable<E>
     : {}


### PR DESCRIPTION
## Summary

- 新增三种 vue-tsc 编译签名模式的完整覆盖（模式 A/A'/B），修复泛型 SFC 因参数自引用导致 Props 提取返回 `any` 的问题
- 拆分为独立内部辅助类型：`_IsAny`、`_InstanceTypeMember`、`_FnParam`、`_FnCtxMember`、`_ReturnCtxMember`
- 精简注释格式，提升可读性

## Test plan

- [ ] 对普通 SFC 组件验证 `ComponentProps` / `ComponentSlots` / `ComponentAttrs` / `ComponentEmit` 类型正确推断
- [ ] 对泛型 SFC（如 `UInput<T>`）验证 Props 不再返回 `any`
- [ ] 对 `DefineComponent` 包装的组件（模式 B）验证各类型提取正常
- [ ] 运行 `pnpm typecheck` 确保无类型错误