### PR TITLE
feat(types): 新增 IsAny、WidenLiteral、Prettify、KnownKeys 类型工具

### DIFF
--- a/docs/content/docs/7.types/general.md
+++ b/docs/content/docs/7.types/general.md
@@ -74,9 +74,9 @@ export type IsAny<T> = 0 extends (1 & T) ? true : false
 ```ts [Example]
 import type { IsAny } from '@movk/core'
 
-type A = IsAny<any>     // true
-type B = IsAny<string>  // false
-type C = IsAny<never>   // false
+type A = IsAny<any> // true
+type B = IsAny<string> // false
+type C = IsAny<never> // false
 type D = IsAny<unknown> // false
 ```
 
@@ -98,11 +98,11 @@ export type WidenLiteral<T>
 ```ts [Example]
 import type { WidenLiteral } from '@movk/core'
 
-type A = WidenLiteral<'hello'>           // string
-type B = WidenLiteral<true>              // boolean
+type A = WidenLiteral<'hello'> // string
+type B = WidenLiteral<true> // boolean
 type C = WidenLiteral<'foo' | undefined> // string | undefined
-type D = WidenLiteral<number>            // number（非字面量，保持原样）
-type E = WidenLiteral<any>              // any（保持原样）
+type D = WidenLiteral<number> // number（非字面量，保持原样）
+type E = WidenLiteral<any> // any（保持原样）
 ```
 
 ## Changelog

--- a/docs/content/docs/7.types/general.md
+++ b/docs/content/docs/7.types/general.md
@@ -61,6 +61,50 @@ type MaybeString = string | null | undefined
 type Result = StripNullable<MaybeString>
 ```
 
+## `IsAny<T>`
+
+检测类型 `T` 是否为 `any`。
+
+利用 `any` 会穿透类型运算的特性（`1 & any` 为 `any`，`0 extends any` 为 `true`）实现检测。
+
+```ts [Source]
+export type IsAny<T> = 0 extends (1 & T) ? true : false
+```
+
+```ts [Example]
+import type { IsAny } from '@movk/core'
+
+type A = IsAny<any>     // true
+type B = IsAny<string>  // false
+type C = IsAny<never>   // false
+type D = IsAny<unknown> // false
+```
+
+## `WidenLiteral<T>`
+
+将字面量类型宽化为其对应的基础类型，同时保留可选性（`undefined`）。
+
+主要用于工厂方法的 props 推断，防止 SFC 泛型默认参数产生的字面量类型污染调用签名。
+
+```ts [Source]
+export type WidenLiteral<T>
+  = IsAny<T> extends true ? T
+    : [NonNullable<T>] extends [never] ? unknown
+        : NonNullable<T> extends boolean ? boolean | Extract<T, undefined>
+          : NonNullable<T> extends string ? string | Extract<T, undefined>
+            : T
+```
+
+```ts [Example]
+import type { WidenLiteral } from '@movk/core'
+
+type A = WidenLiteral<'hello'>           // string
+type B = WidenLiteral<true>              // boolean
+type C = WidenLiteral<'foo' | undefined> // string | undefined
+type D = WidenLiteral<number>            // number（非字面量，保持原样）
+type E = WidenLiteral<any>              // any（保持原样）
+```
+
 ## Changelog
 
 :commit-changelog{prefix="types"}

--- a/docs/content/docs/7.types/object.md
+++ b/docs/content/docs/7.types/object.md
@@ -243,6 +243,60 @@ type T1 = GetFieldValue<User, 'tags'>
 type T2 = GetFieldValue<User, 'profile.bio'>
 ```
 
+## `Prettify<T>`
+
+强制 TypeScript 展平类型别名，使 IntelliSense 能完整枚举对象的所有属性。
+
+常用于消除交叉类型（`A & B`）的「折叠」显示，让 IDE 悬停时直接展示合并后的属性列表。
+
+```ts [Source]
+export type Prettify<T> = { [K in keyof T]: T[K] } & {}
+```
+
+```ts [Example]
+import type { Prettify } from '@movk/core'
+
+type A = { a: number } & { b: string }
+// IDE hover 显示 "{ a: number } & { b: string }"
+
+type B = Prettify<A>
+// IDE hover 显示 "{ a: number; b: string }"
+```
+
+## `KnownKeys<T>`
+
+从对象类型中提取所有字面量键，过滤掉索引签名（`string`、`number`、`symbol`）。
+
+适用于具体对象类型，常用于泛型工厂方法中精确枚举注册项的键名，防止 `string` 索引污染 IntelliSense 补全。
+
+::callout{icon="i-lucide-info"}
+当 TypeScript 的 `keyof T` 本身已是 `string`（如纯索引签名类型 `{ [key: string]: ... }`），`KnownKeys<T>` 返回 `never`。此类型仅对具体对象类型（键名为字面量）有效。
+::
+
+```ts [Source]
+export type KnownKeys<T> = {
+  [K in keyof T]-?: string extends K
+    ? never
+    : number extends K
+      ? never
+      : symbol extends K
+        ? never
+        : K
+}[keyof T]
+```
+
+```ts [Example]
+import type { KnownKeys } from '@movk/core'
+
+// 具体对象类型：返回所有字面量键
+type Controls = { text: string, select: number }
+type K = KnownKeys<Controls> // 'text' | 'select'
+
+// 纯索引签名类型：返回 never
+type Indexed = { [key: string]: string }
+type L = KnownKeys<Indexed> // never
+```
+
 ## Changelog
 
 :commit-changelog{prefix="types/object"}

--- a/docs/content/docs/7.types/object.md
+++ b/docs/content/docs/7.types/object.md
@@ -289,11 +289,11 @@ export type KnownKeys<T> = {
 import type { KnownKeys } from '@movk/core'
 
 // 具体对象类型：返回所有字面量键
-type Controls = { text: string, select: number }
+interface Controls { text: string, select: number }
 type K = KnownKeys<Controls> // 'text' | 'select'
 
 // 纯索引签名类型：返回 never
-type Indexed = { [key: string]: string }
+interface Indexed { [key: string]: string }
 type L = KnownKeys<Indexed> // never
 ```
 

--- a/docs/content/docs/7.types/vue.md
+++ b/docs/content/docs/7.types/vue.md
@@ -9,56 +9,95 @@ links:
 
 这些类型主要用于在 TypeScript 环境下更精确地推断 Vue 组件的 `props`、`slots`、`emits` 等。
 
-## `ComponentProps<T>`
+组件提取类型支持三种 vue-tsc 编译签名模式：
 
-从一个组件类型 `T` 中提取其 `props` 类型。
+- **模式 A**：函数参数可直接解析（`Parameters<T>[0]`）
+- **模式 A'**：参数自引用（返回 `any`）→ 从返回值 `__ctx` 成员提取
+- **模式 B**：`DefineComponent` 包装 → `InstanceType<T>['$props']`
+
+## `IsComponent`
+
+表示任意合法 Vue 组件类型的联合类型，涵盖字符串、`VNode`、`Component` 及 `DefineComponent`。
 
 ```ts [Source]
-export type ComponentProps<T> = T extends new (...args: any) => { $props: infer P } ? NonNullable<P>
-  : T extends (props: infer P, ...args: any) => any ? P
-    : {}
+export type IsComponent = StringOrVNode | Component | DefineComponent | ((...args: any[]) => any)
+```
+
+## `ComponentProps<T>`
+
+从组件类型 `T` 中提取其 `props` 类型，支持三种 vue-tsc 编译模式，能正确处理泛型 SFC（如 `UInput`）因参数自引用导致 `Props` 提取返回 `any` 的问题。
+
+```ts [Source]
+export type ComponentProps<T>
+  = _FnParam<T> extends never
+    ? _ReturnCtxMember<T, 'props'> extends never
+      ? _InstanceTypeMember<T, '$props'> extends never ? {} : NonNullable<_InstanceTypeMember<T, '$props'>>
+      : NonNullable<_ReturnCtxMember<T, 'props'>>
+    : _FnParam<T>
 ```
 
 ```ts [Example]
 import MyComponent from './MyComponent.vue'
+import type { ComponentProps } from '@movk/core'
 
 type Props = ComponentProps<typeof MyComponent>
-// Props will be the type of MyComponent's props
+// Props 为 MyComponent 的完整 props 类型，包括泛型 SFC
 ```
 
 ## `ComponentSlots<T>`
 
-从一个组件类型 `T` 中提取其 `slots` 类型。
+从组件类型 `T` 中提取其 `slots` 类型，支持三种 vue-tsc 编译模式。
 
 ```ts [Source]
-export type ComponentSlots<T> = T extends new (...args: any) => { $slots: infer S } ? NonNullable<S>
-  : T extends (props: any, ctx: { slots: infer S, attrs: any, emit: any }, ...args: any) => any ? NonNullable<S>
-    : {}
+export type ComponentSlots<T>
+  = _IsAny<_FnCtxMember<T, 'slots'>> extends true
+    ? _ReturnCtxMember<T, 'slots'> extends never
+      ? _InstanceTypeMember<T, '$slots'> extends never ? {} : NonNullable<_InstanceTypeMember<T, '$slots'>>
+      : _ReturnCtxMember<T, 'slots'>
+    : [_FnCtxMember<T, 'slots'>] extends [never]
+        ? _ReturnCtxMember<T, 'slots'> extends never
+          ? _InstanceTypeMember<T, '$slots'> extends never ? {} : NonNullable<_InstanceTypeMember<T, '$slots'>>
+          : _ReturnCtxMember<T, 'slots'>
+        : _FnCtxMember<T, 'slots'>
 ```
 
 ## `ComponentAttrs<T>`
 
-从一个组件类型 `T` 中提取其 `attrs` 类型。
+从组件类型 `T` 中提取其 `attrs` 类型，支持三种 vue-tsc 编译模式。
 
 ```ts [Source]
-export type ComponentAttrs<T> = T extends new (...args: any) => { $attrs: infer A } ? NonNullable<A>
-  : T extends (props: any, ctx: { slots: any, attrs: infer A, emit: any }, ...args: any) => any ? NonNullable<A>
-    : {}
+export type ComponentAttrs<T>
+  = _IsAny<_FnCtxMember<T, 'attrs'>> extends true
+    ? _ReturnCtxMember<T, 'attrs'> extends never
+      ? _InstanceTypeMember<T, '$attrs'> extends never ? {} : NonNullable<_InstanceTypeMember<T, '$attrs'>>
+      : _ReturnCtxMember<T, 'attrs'>
+    : [_FnCtxMember<T, 'attrs'>] extends [never]
+        ? _ReturnCtxMember<T, 'attrs'> extends never
+          ? _InstanceTypeMember<T, '$attrs'> extends never ? {} : NonNullable<_InstanceTypeMember<T, '$attrs'>>
+          : _ReturnCtxMember<T, 'attrs'>
+        : _FnCtxMember<T, 'attrs'>
 ```
 
 ## `ComponentEmit<T>`
 
-从一个组件类型 `T` 中提取其 `emit` 函数的类型。
+从组件类型 `T` 中提取其 `emit` 函数的类型，支持三种 vue-tsc 编译模式。
 
 ```ts [Source]
-export type ComponentEmit<T> = T extends new (...args: any) => { $emit: infer E } ? NonNullable<E>
-  : T extends (props: any, ctx: { slots: any, attrs: any, emit: infer E }, ...args: any) => any ? NonNullable<E>
-    : {}
+export type ComponentEmit<T>
+  = _IsAny<_FnCtxMember<T, 'emit'>> extends true
+    ? _ReturnCtxMember<T, 'emit'> extends never
+      ? _InstanceTypeMember<T, '$emit'> extends never ? {} : NonNullable<_InstanceTypeMember<T, '$emit'>>
+      : _ReturnCtxMember<T, 'emit'>
+    : [_FnCtxMember<T, 'emit'>] extends [never]
+        ? _ReturnCtxMember<T, 'emit'> extends never
+          ? _InstanceTypeMember<T, '$emit'> extends never ? {} : NonNullable<_InstanceTypeMember<T, '$emit'>>
+          : _ReturnCtxMember<T, 'emit'>
+        : _FnCtxMember<T, 'emit'>
 ```
 
 ## `ComponentExposed<T>`
 
-从一个组件类型 `T` 中提取其 `expose` 的类型。
+从组件类型 `T` 中提取其 `expose` 的类型。
 
 ```ts [Source]
 export type ComponentExposed<T> = T extends new (...args: any) => infer E ? E

--- a/docs/content/docs/7.types/vue.md
+++ b/docs/content/docs/7.types/vue.md
@@ -37,8 +37,8 @@ export type ComponentProps<T>
 ```
 
 ```ts [Example]
-import MyComponent from './MyComponent.vue'
 import type { ComponentProps } from '@movk/core'
+import MyComponent from './MyComponent.vue'
 
 type Props = ComponentProps<typeof MyComponent>
 // Props 为 MyComponent 的完整 props 类型，包括泛型 SFC

--- a/src/types/general.ts
+++ b/src/types/general.ts
@@ -34,3 +34,44 @@ export type ReactiveValue<T, CTX = never> = [CTX] extends [never]
   : MaybeRefOrGetter<T> | ((ctx: CTX) => T)
 
 export type StripNullable<T> = T extends null | undefined ? never : T
+
+/**
+ * 检测类型 T 是否为 `any`
+ *
+ * 利用 `any` 会穿透类型运算的特性（`1 & any` 为 `any`，`0 extends any` 为 `true`）实现检测。
+ *
+ * @example
+ * ```ts
+ * type A = IsAny<any>     // true
+ * type B = IsAny<string>  // false
+ * type C = IsAny<never>   // false
+ * type D = IsAny<unknown> // false
+ * ```
+ */
+export type IsAny<T> = 0 extends (1 & T) ? true : false
+
+/**
+ * 将字面量类型宽化为其对应的基础类型，同时保留可选性（`undefined`）。
+ *
+ * - `any` → 保持原样
+ * - `undefined | never` → `unknown`
+ * - `boolean` 字面量 → `boolean`
+ * - `string` 字面量 → `string`
+ * - 其他类型 → 保持原样
+ *
+ * 主要用于工厂方法的 props 推断，防止 SFC 泛型默认参数产生的字面量类型污染调用签名。
+ *
+ * @example
+ * ```ts
+ * type A = WidenLiteral<'hello'>           // string
+ * type B = WidenLiteral<true>              // boolean
+ * type C = WidenLiteral<'foo' | undefined> // string | undefined
+ * type D = WidenLiteral<number>            // number
+ * ```
+ */
+export type WidenLiteral<T>
+  = IsAny<T> extends true ? T
+    : [NonNullable<T>] extends [never] ? unknown
+        : NonNullable<T> extends boolean ? boolean | Extract<T, undefined>
+          : NonNullable<T> extends string ? string | Extract<T, undefined>
+            : T

--- a/src/types/object/utilities.ts
+++ b/src/types/object/utilities.ts
@@ -30,3 +30,47 @@ export type FirstParam<T, K extends keyof T> = T[K] extends [infer P, ...any[]] 
  * // 结果: R 为 number; 若 T 非函数，则为 undefined
  */
 export type FirstParameter<T> = T extends (arg: infer P, ...args: any[]) => any ? P : undefined
+
+/**
+ * 强制 TypeScript 展平类型别名，使 IntelliSense 能完整枚举对象的所有属性。
+ *
+ * 常用于消除交叉类型（`A & B`）的「折叠」显示，让 IDE 悬停时直接展示合并后的属性列表。
+ *
+ * @typeParam T - 要展平的对象类型
+ * @example
+ * ```ts
+ * type A = { a: number } & { b: string }
+ * // IDE hover 显示 "{ a: number } & { b: string }"
+ *
+ * type B = Prettify<A>
+ * // IDE hover 显示 "{ a: number; b: string }"
+ * ```
+ */
+export type Prettify<T> = { [K in keyof T]: T[K] } & {}
+
+/**
+ * 从对象类型中提取所有字面量键，过滤掉索引签名（`string`、`number`、`symbol`）。
+ *
+ * 用于需要精确枚举已知属性而不被索引签名污染 IntelliSense 的场景。
+ *
+ * @typeParam T - 可能含索引签名的对象类型
+ * @example
+ * ```ts
+ * interface Config {
+ *   debug: boolean
+ *   timeout: number
+ *   [key: string]: unknown
+ * }
+ * // K = 'debug' | 'timeout'（索引签名 string 被过滤掉）
+ * type K = KnownKeys<Config>
+ * ```
+ */
+export type KnownKeys<T> = {
+  [K in keyof T]-?: string extends K
+    ? never
+    : number extends K
+      ? never
+      : symbol extends K
+        ? never
+        : K
+}[keyof T]

--- a/tests/types/general.test.ts
+++ b/tests/types/general.test.ts
@@ -1,4 +1,4 @@
-import type { ReactiveValue, StripNullable, Suggest } from '../../src/types/general'
+import type { IsAny, ReactiveValue, StripNullable, Suggest, WidenLiteral } from '../../src/types/general'
 import { describe, expectTypeOf, it } from 'vitest'
 
 describe('通用类型工具', () => {
@@ -47,5 +47,23 @@ describe('通用类型工具', () => {
     expectTypeOf<StripNullable<string | null | undefined>>().toEqualTypeOf<string>()
     expectTypeOf<StripNullable<number | null>>().toEqualTypeOf<number>()
     expectTypeOf<StripNullable<string | undefined>>().toEqualTypeOf<string>()
+  })
+
+  it('isAny', () => {
+    expectTypeOf<IsAny<any>>().toEqualTypeOf<true>()
+    expectTypeOf<IsAny<string>>().toEqualTypeOf<false>()
+    expectTypeOf<IsAny<never>>().toEqualTypeOf<false>()
+    expectTypeOf<IsAny<unknown>>().toEqualTypeOf<false>()
+    expectTypeOf<IsAny<object>>().toEqualTypeOf<false>()
+  })
+
+  it('widenLiteral', () => {
+    expectTypeOf<WidenLiteral<'hello'>>().toEqualTypeOf<string>()
+    expectTypeOf<WidenLiteral<true>>().toEqualTypeOf<boolean>()
+    expectTypeOf<WidenLiteral<false>>().toEqualTypeOf<boolean>()
+    expectTypeOf<WidenLiteral<'foo' | undefined>>().toEqualTypeOf<string | undefined>()
+    expectTypeOf<WidenLiteral<number>>().toEqualTypeOf<number>()
+    expectTypeOf<WidenLiteral<any>>().toEqualTypeOf<any>()
+    expectTypeOf<WidenLiteral<never>>().toEqualTypeOf<unknown>()
   })
 })

--- a/tests/types/object.test.ts
+++ b/tests/types/object.test.ts
@@ -1,0 +1,31 @@
+import type { KnownKeys, Prettify, UnionToIntersection } from '../../src/types/object'
+import { describe, expectTypeOf, it } from 'vitest'
+
+describe('对象类型工具', () => {
+  it('unionToIntersection', () => {
+    type U = { a: number } | { b: string }
+    type R = UnionToIntersection<U>
+
+    expectTypeOf<R>().toMatchObjectType<{ a: number }>()
+    expectTypeOf<R>().toMatchObjectType<{ b: string }>()
+  })
+
+  it('prettify - 展平交叉类型', () => {
+    type A = { a: number } & { b: string }
+    type B = Prettify<A>
+
+    expectTypeOf<B>().toEqualTypeOf<{ a: number, b: string }>()
+  })
+
+  it('knownKeys - 普通对象类型返回所有字面量键', () => {
+    interface _Controls { text: string, select: number, checkbox: boolean }
+    type K = KnownKeys<_Controls>
+    expectTypeOf<K>().toEqualTypeOf<'text' | 'select' | 'checkbox'>()
+  })
+
+  it('knownKeys - 纯索引签名类型返回 never', () => {
+    interface _Indexed { [key: string]: string }
+    type K = KnownKeys<_Indexed>
+    expectTypeOf<K>().toEqualTypeOf<never>()
+  })
+})


### PR DESCRIPTION
## Summary

- **`IsAny<T>`**（`general.ts`）：利用 `any` 穿透类型运算的特性检测 `any`，为其他类型工具提供基础防御
- **`WidenLiteral<T>`**（`general.ts`）：将字面量类型宽化为基础类型（`'foo'` → `string`，`true` → `boolean`），保留 `undefined` 可选性；主要用于工厂方法 props 推断场景
- **`Prettify<T>`**（`object/utilities.ts`）：展平交叉类型，消除 IDE 悬停时的「折叠」显示，提升 IntelliSense 可读性
- **`KnownKeys<T>`**（`object/utilities.ts`）：从具体对象类型中提取字面量键，过滤 `string`/`number`/`symbol` 索引签名
- **删除 movk-nuxt 中 `UnionToIntersection` 的本地重复定义**，改为从 `@movk/core` 导入
- **补充 `vue.md` 文档**，同步 PR #69 引入的三模式编译签名重构（`IsComponent`、`ComponentType`、重构后的 `ComponentProps/Slots/Attrs/Emit`）

## Test plan

- [x] `pnpm test --run`：370 tests passed
- [x] `pnpm typecheck`：tsc + nuxt typecheck 无错误
- [x] 新增 `tests/types/object.test.ts`（`UnionToIntersection`、`Prettify`、`KnownKeys`）
- [x] `tests/types/general.test.ts` 补充 `IsAny` 和 `WidenLiteral` 用例