### PR TITLE
fix(clean): 修复 pnpm workspace symlink 导致源码被删除的问题

### DIFF
--- a/bin/clean.mjs
+++ b/bin/clean.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
-import { rm } from 'node:fs/promises'
-import { relative, resolve } from 'node:path'
+import { lstat, rm } from 'node:fs/promises'
+import { basename, relative, resolve } from 'node:path'
 import process from 'node:process'
 import { glob } from 'tinyglobby'
 
@@ -11,68 +11,75 @@ const DEFAULT_TARGETS = [
   '.output',
   '.cache',
   'dist',
-  'dist.zip'
+  'dist.zip',
 ]
-const BATCH_SIZE = 10
-
-async function removePath(path) {
-  try {
-    await rm(path, { recursive: true, force: true, maxRetries: 3 })
-    return { path, success: true }
-  }
-  catch (e) {
-    if (e.code === 'ENOENT')
-      return { path, success: true }
-    return { path, success: false, error: e.message }
-  }
-}
-
-async function processBatch(paths) {
-  const results = []
-  for (let i = 0; i < paths.length; i += BATCH_SIZE) {
-    const batch = paths.slice(i, i + BATCH_SIZE)
-    results.push(...await Promise.all(batch.map(removePath)))
-  }
-  return results
-}
+const RE_PATH_SEP = /[/\\]/
+const RE_TRAILING_SLASH = /\/+$/
 
 async function clean() {
   const start = Date.now()
   const args = process.argv.slice(2)
-  const targets = args.length > 0 ? args : DEFAULT_TARGETS
+  const targets = (args.length > 0 ? args : DEFAULT_TARGETS)
+    .filter(t => t && !RE_PATH_SEP.test(t) && t !== '.' && t !== '..')
   const root = resolve(process.cwd())
+  const targetSet = new Set(targets)
 
-  let paths
-  try {
-    paths = await glob(targets.map(t => `**/${t}`), {
-      cwd: root,
-      onlyFiles: false,
-      dot: true,
-      absolute: true,
-      ignore: ['**/node_modules/**/node_modules/**'],
-    })
-  }
-  catch (e) {
-    console.error('搜索失败:', e.message)
-    process.exit(1)
+  if (targets.length === 0) {
+    console.log('没有有效的清理目标')
+    return
   }
 
-  if (!paths.length) {
+  const rawPaths = await glob(targets.map(t => `**/${t}`), {
+    cwd: root,
+    onlyFiles: false,
+    dot: true,
+    absolute: true,
+    followSymbolicLinks: false,
+    ignore: ['**/.git/**'],
+  })
+
+  const matched = Array.from(new Set(rawPaths), p => p.replace(RE_TRAILING_SLASH, ''))
+    .filter(p => p !== root && p.startsWith(`${root}/`) && targetSet.has(basename(p)))
+    .sort((a, b) => a.length - b.length)
+
+  const deduped = []
+  for (const p of matched) {
+    if (!deduped.some(parent => p.startsWith(`${parent}/`)))
+      deduped.push(p)
+  }
+
+  const paths = []
+  for (const p of deduped) {
+    try {
+      if ((await lstat(p)).isSymbolicLink())
+        continue
+    }
+    catch { continue }
+    paths.push(p)
+  }
+
+  if (paths.length === 0) {
     console.log('未找到需要清理的目标')
     return
   }
 
-  paths = new Set(paths).toSorted((a, b) => b.length - a.length)
+  paths.forEach(p => console.log(`  ${relative(root, p)}`))
 
-  const results = await processBatch(paths)
-  const removed = results.filter(r => r.success).length
-  const failed = results.filter(r => !r.success)
+  const results = await Promise.all(paths.map(async (p) => {
+    try {
+      await rm(p, { recursive: true, force: true, maxRetries: 3 })
+      return null
+    }
+    catch (e) {
+      return e.code === 'ENOENT' ? null : { path: p, error: e.message }
+    }
+  }))
+
+  const failed = results.filter(Boolean)
   const duration = ((Date.now() - start) / 1000).toFixed(2)
-
-  console.log(`已清理 ${removed}/${results.length} 项，耗时 ${duration}s`)
+  console.log(`已清理 ${paths.length - failed.length}/${paths.length} 项，耗时 ${duration}s`)
 
   if (failed.length) {
-    console.warn(`\n${failed.length} 项清理失败:`)
     failed.forEach(f => console.warn(`  ${relative(root, f.path)}: ${f.error}`))
     process.exit(1)
   }


### PR DESCRIPTION
## 问题

在 pnpm workspace 环境下执行 `pnpm clean` 会删除项目所有源码文件。

**根因链：**

1. `Set.prototype.toSorted()` 不是标准 JS 方法，脚本在 Node.js v24 中直接崩溃
2. 用户修复 `toSorted()` 后，`tinyglobby` 的 `onlyFiles: false` 会展开目录匹配的所有后代，导致 glob 遍历 `docs/node_modules/@movk/core -> ../../..`（pnpm workspace symlink，指向项目根目录）
3. `rm({ recursive: true })` 依次删除 `src/`、`tests/`、`package.json` 等项目源码

## 修复

| 问题 | 修复方式 |
|------|---------|
| `Set.toSorted()` 崩溃 | 改为 `Array.from(new Set(), mapFn).sort()` |
| symlink 遍历源码 | `followSymbolicLinks: false` + `lstat` symlink 检查 |
| 目录后代展开冗余 | basename 过滤 + 祖先去重（62332 路径 → 4 项） |
| 危险命令行参数 | 校验拒绝含路径分隔符、`.`、`..` 的输入 |
| `.git` 保护 | `ignore: ['**/.git/**']` |
| 无意义批处理 | 去重后目标只有 4-6 个，直接 `Promise.all` |

## 测试计划

- [ ] 在 pnpm workspace 项目中运行 `pnpm clean`，确认只删除 `node_modules`、`.nuxt`、`.data` 等目标，源码文件完整
- [ ] 确认 `docs/node_modules/@movk/core` symlink 被正确跳过
- [ ] 传入危险参数（如 `..`、`/etc`）验证被安全过滤
- [ ] 运行 `npx eslint bin/clean.mjs` 确认零错误