### PR TITLE
chore: 更新 @movk/nuxt-docs 依赖版本

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,7 +26,7 @@ jobs:
           cache: pnpm
 
       - name: Restore Nuxt build cache
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: |
             docs/.nuxt


### PR DESCRIPTION
将 @movk/nuxt-docs 从 PR 预发布版本更新为稳定的 2.0.0 版本。